### PR TITLE
Don't compute Hessian when using first order in Ipopt and make it default

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ r.minimum
 r.minimizer
 ```
 
+## NLopt
+
+```julia
+alg = NLoptAlg(:LD_MMA)
+options = Nonconvex.NLoptOptions()
+r = optimize(m, alg, [1.234, 2.345], options = options)
+r.minimum
+r.minimizer
+```
+
 ## Augmented Lagrangian
 
 ```julia
@@ -71,21 +81,23 @@ r.minimum
 r.minimizer
 ```
 
+## Mixed equality and inequality constraints
+
+```julia
+f(x) = sqrt(x[2])
+g(x, a, b) = (a*x[1] + b)^3 - x[2]
+
+m = Model(f)
+addvar!(m, [0.0, 0.0], [10.0, 10.0])
+add_eq_constraint!(m, x -> g(x, 2, 0))
+add_ineq_constraint!(m, x -> g(x, -1, 1))
+```
+
 ## Ipopt
 
 ```julia
 alg = IpoptAlg()
 options = Nonconvex.IpoptOptions()
-r = optimize(m, alg, [1.234, 2.345], options = options)
-r.minimum
-r.minimizer
-```
-
-## NLopt
-
-```julia
-alg = NLoptAlg(:LD_MMA)
-options = Nonconvex.NLoptOptions()
 r = optimize(m, alg, [1.234, 2.345], options = options)
 r.minimum
 r.minimizer

--- a/src/Nonconvex.jl
+++ b/src/Nonconvex.jl
@@ -6,6 +6,7 @@ const show_residuals = Ref(false)
 export  Model,
         addvar!,
         add_ineq_constraint!,
+        add_eq_constraint!,
         getmin,
         getmax,
         setmin!,

--- a/test/ipopt.jl
+++ b/test/ipopt.jl
@@ -3,35 +3,11 @@ using Nonconvex, LinearAlgebra, Test
 f(x::AbstractVector) = sqrt(x[2])
 g(x::AbstractVector, a, b) = (a*x[1] + b)^3 - x[2]
 
-options = IpoptOptions()
-
-@testset "Simple constraints" begin
-    m = Model(f)
-    addvar!(m, [0.0, 0.0], [10.0, 10.0])
-    add_ineq_constraint!(m, x -> g(x, 2, 0))
-    add_ineq_constraint!(m, x -> g(x, -1, 1))
-
-    alg = IpoptAlg()
-    r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
-    @test abs(r.minimum - sqrt(8/27)) < 1e-6
-    @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
-end
-
-@testset "Block constraints" begin
-    m = Model(f)
-    addvar!(m, [0.0, 0.0], [10.0, 10.0])
-    add_ineq_constraint!(m, FunctionWrapper(x -> [g(x, 2, 0), g(x, -1, 1)], 2))
-
-    alg = IpoptAlg()
-    r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
-    @test abs(r.minimum - sqrt(8/27)) < 1e-6
-    @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
-end
-
-@testset "Infinite bounds" begin
-    @testset "Infinite upper bound" begin
+@testset "First order - $first_order" for first_order in [true, false]
+    options = IpoptOptions(first_order = first_order)
+    @testset "Simple constraints" begin
         m = Model(f)
-        addvar!(m, [0.0, 0.0], [Inf, Inf])
+        addvar!(m, [0.0, 0.0], [10.0, 10.0])
         add_ineq_constraint!(m, x -> g(x, 2, 0))
         add_ineq_constraint!(m, x -> g(x, -1, 1))
 
@@ -40,26 +16,51 @@ end
         @test abs(r.minimum - sqrt(8/27)) < 1e-6
         @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
     end
-    @testset "Infinite lower bound" begin
+
+    @testset "Block constraints" begin
         m = Model(f)
-        addvar!(m, [-Inf, -Inf], [10, 10])
-        add_ineq_constraint!(m, x -> g(x, 2, 0))
-        add_ineq_constraint!(m, x -> g(x, -1, 1))
+        addvar!(m, [0.0, 0.0], [10.0, 10.0])
+        add_ineq_constraint!(m, FunctionWrapper(x -> [g(x, 2, 0), g(x, -1, 1)], 2))
 
         alg = IpoptAlg()
         r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
         @test abs(r.minimum - sqrt(8/27)) < 1e-6
         @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
     end
-    @testset "Infinite upper and lower bound" begin
-        m = Model(f)
-        addvar!(m, [-Inf, -Inf], [Inf, Inf])
-        add_ineq_constraint!(m, x -> g(x, 2, 0))
-        add_ineq_constraint!(m, x -> g(x, -1, 1))
 
-        alg = IpoptAlg()
-        r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
-        @test abs(r.minimum - sqrt(8/27)) < 1e-6
-        @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
+    @testset "Infinite bounds" begin
+        @testset "Infinite upper bound" begin
+            m = Model(f)
+            addvar!(m, [0.0, 0.0], [Inf, Inf])
+            add_ineq_constraint!(m, x -> g(x, 2, 0))
+            add_ineq_constraint!(m, x -> g(x, -1, 1))
+
+            alg = IpoptAlg()
+            r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
+            @test abs(r.minimum - sqrt(8/27)) < 1e-6
+            @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
+        end
+        @testset "Infinite lower bound" begin
+            m = Model(f)
+            addvar!(m, [-Inf, -Inf], [10, 10])
+            add_ineq_constraint!(m, x -> g(x, 2, 0))
+            add_ineq_constraint!(m, x -> g(x, -1, 1))
+
+            alg = IpoptAlg()
+            r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
+            @test abs(r.minimum - sqrt(8/27)) < 1e-6
+            @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
+        end
+        @testset "Infinite upper and lower bound" begin
+            m = Model(f)
+            addvar!(m, [-Inf, -Inf], [Inf, Inf])
+            add_ineq_constraint!(m, x -> g(x, 2, 0))
+            add_ineq_constraint!(m, x -> g(x, -1, 1))
+
+            alg = IpoptAlg()
+            r = Nonconvex.optimize(m, alg, [1.234, 2.345], options = options)
+            @test abs(r.minimum - sqrt(8/27)) < 1e-6
+            @test norm(r.minimizer - [1/3, 8/27]) < 1e-6
+        end
     end
 end


### PR DESCRIPTION
This removes the initial computation of the Hessian when using l-BFGS approximation of the Hessian in Ipopt. This is also the default now. This PR should fix #14.